### PR TITLE
Account for queried sequences returning no hits

### DIFF
--- a/.github/workflows/test-cockatoo.yml
+++ b/.github/workflows/test-cockatoo.yml
@@ -19,9 +19,9 @@ jobs:
           activate-environment: test
           environment-file: cockatoo.yml
           python-version: ${{ matrix.python-version }}
+          miniforge-variant: Mambaforge
           auto-activate-base: false
-          mamba-version: "*"
-          channels: conda-forge,bioconda,defaults
+          channels: conda-forge,bioconda
       - run: |
           conda info
           conda list

--- a/cockatoo/workflow/scripts/query_processing.py
+++ b/cockatoo/workflow/scripts/query_processing.py
@@ -11,8 +11,10 @@ def processing(
     SEQUENCE_IDENTITY=0.86,
     WINDOW_SIZE=60):
 
+    output_columns = ["gene", "sample", "sequence", "num_hits", "coverage", "taxonomy", "found_in"]
+
     if len(query_read) == 0:
-        empty_output = pd.DataFrame(columns=["gene", "sample", "sequence", "num_hits", "coverage", "taxonomy", "found_in"])
+        empty_output = pd.DataFrame(columns=output_columns)
         return empty_output, empty_output
 
     appraised = (query_read
@@ -34,7 +36,8 @@ def processing(
     # Split dataframe into binned/unbinned
     appraised["binned"] = appraised["divergence"].apply(lambda x: x <= (1 - SEQUENCE_IDENTITY) * WINDOW_SIZE)
     binned = appraised[appraised["binned"]].drop(["divergence", "binned"], axis = 1).reset_index(drop = True)
-    unbinned = appraised[~appraised["binned"]].drop(["divergence", "binned"], axis = 1).reset_index(drop = True)
+    unbinned = pipe_read.join(appraised.set_index(output_columns[0:-1]), on = output_columns[0:-1])
+    unbinned = unbinned[~unbinned["binned"].fillna(False)].drop(["divergence", "binned"], axis = 1).reset_index(drop = True)
     unbinned["found_in"] = None
 
     return binned, unbinned

--- a/test/test_query_processing.py
+++ b/test/test_query_processing.py
@@ -54,7 +54,6 @@ class Tests(unittest.TestCase):
             ["sample_1", "AAB", 10, 5, 10, "genome_1", "S3.1", "AAA", "Root"],
         ], columns=QUERY_COLUMNS)
         pipe = pd.DataFrame([
-            ["S3.1", "sample_1", "AAA", 5, 10, "Root"],
             ["S3.1", "sample_1", "AAB", 5, 10, "Root"],
         ], columns=PIPE_COLUMNS)
 
@@ -75,7 +74,6 @@ class Tests(unittest.TestCase):
         ], columns=QUERY_COLUMNS)
         pipe = pd.DataFrame([
             ["S3.1", "sample_1", "AAA", 5, 10, "Root"],
-            ["S3.1", "sample_1", "AAB", 5, 10, "Root"],
         ], columns=PIPE_COLUMNS)
 
         expected_binned = pd.DataFrame([
@@ -86,6 +84,26 @@ class Tests(unittest.TestCase):
 
         observed_binned, observed_unbinned = processing(query, pipe)
         observed_unbinned.index = []
+        self.assertDataFrameEqual(expected_binned, observed_binned)
+        self.assertDataFrameEqual(expected_unbinned, observed_unbinned)
+
+    def test_query_processing_extra_pipe_entries(self):
+        query = pd.DataFrame([
+            ["sample_1", "AAA", 1, 20, 50, "genome_1", "S3.1", "AAA", "Root"],
+        ], columns=QUERY_COLUMNS)
+        pipe = pd.DataFrame([
+            ["S3.1", "sample_1", "AAA", 5, 10, "Root"],
+            ["S3.1", "sample_1", "AAB", 5, 10, "Root"],
+        ], columns=PIPE_COLUMNS)
+
+        expected_binned = pd.DataFrame([
+            ["S3.1", "sample_1", "AAA", 5, 10, "Root", "genome_1"],
+        ], columns=APPRAISE_COLUMNS)
+        expected_unbinned = pd.DataFrame([
+            ["S3.1", "sample_1", "AAB", 5, 10, "Root", None],
+        ], columns=APPRAISE_COLUMNS)
+
+        observed_binned, observed_unbinned = processing(query, pipe)
         self.assertDataFrameEqual(expected_binned, observed_binned)
         self.assertDataFrameEqual(expected_unbinned, observed_unbinned)
 


### PR DESCRIPTION
With new query arg `--max-divergence`, hits outside of that number are not returned